### PR TITLE
add support for ROS 2 Jazzy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,17 +8,16 @@ on:
   workflow_dispatch:
 jobs:
   build-and-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         ros_distribution:
           - humble
+          - jazzy
           - rolling
-
     container:
       image: ros:${{ matrix.ros_distribution }}
-
     steps:
       - name: build and test ROS 2
         uses: ros-tooling/action-ros-ci@v0.3

--- a/include/bag_to_image/bag_to_image.hpp
+++ b/include/bag_to_image/bag_to_image.hpp
@@ -35,7 +35,11 @@
 #include <filesystem>
 #include <opencv2/opencv.hpp>
 #include "rclcpp/rclcpp.hpp"
+#if __has_include("cv_bridge/cv_bridge.hpp") // ROS 2 jazzy and newer
+#include "cv_bridge/cv_bridge.hpp"
+#else // ROS 2 humble
 #include "cv_bridge/cv_bridge.h"
+#endif
 #include "image_transport/image_transport.hpp"
 #include "boost/lexical_cast.hpp"
 #include "rclcpp/serialization.hpp"

--- a/include/topic_to_image/topic_to_image.hpp
+++ b/include/topic_to_image/topic_to_image.hpp
@@ -33,7 +33,11 @@
 #include <filesystem>
 #include <opencv2/opencv.hpp>
 #include "rclcpp/rclcpp.hpp"
+#if __has_include("cv_bridge/cv_bridge.hpp") // ROS 2 jazzy and newer
+#include "cv_bridge/cv_bridge.hpp"
+#else // ROS 2 humble
 #include "cv_bridge/cv_bridge.h"
+#endif
 #include "image_transport/image_transport.hpp"
 #include "boost/lexical_cast.hpp"
 

--- a/src/bag_to_image.cpp
+++ b/src/bag_to_image.cpp
@@ -89,7 +89,11 @@ void BagToImage::ReadBag() {
       if (image_msg == nullptr) {
         RCLCPP_INFO_STREAM(get_logger(), "Could not convert the message to Image type: "
           << bag_message->topic_name
-          << " at " << bag_message->time_stamp);
+#if __has_include("cv_bridge/cv_bridge.hpp") // ROS 2 jazzy and newer
+          << " at " << bag_message->send_timestamp);
+#else // ROS 2 humble
+          << " at " << bag_message->timestamp);
+#endif
         continue;
       }
       std::string fname;


### PR DESCRIPTION
Jazzy is the latest ROS 2 release and the current LTS.

this adds the support in a backwards-compatible way by checking for the presence of the the new `cv_bridge.hpp` header.

the cleaner solution would be to create a branch for Humble support (if/when any other commit is needed for humble) and just upgrade the code to Jazzy in a non-backwards-compatible way. however, i chose this approach since i wasn't sure which you prefer and since there are no other branches to support other ROS releases and Humble is still a supported ROS release.