### PR TITLE
Ensure consistent filename format and separate output directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Set `compressed` to `True` to subscribe to a compressed image_transport.
 ### Parameters
 | Parameter       | Default      | Description                        |
 |-----------------|--------------|------------------------------------|
-| `input/topic`   | `/image_raw` | ROS2 Topic to subscribe            |
+| `input/topics`  | `/image_raw` | ROS2 Topic to subscribe            |
 | `output/path`   | `/tmp/`      | Path where to store the PNG files. |
 | `output/prefix` |              | Text to prepend to the output file |
 

--- a/src/bag_to_image.cpp
+++ b/src/bag_to_image.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "bag_to_image/bag_to_image.hpp"
+#include <boost/format.hpp>
 
 BagToImage::BagToImage(const rclcpp::NodeOptions &options) :
   Node("bag_to_image", options) {
@@ -92,15 +93,16 @@ void BagToImage::ReadBag() {
           << " at " << bag_message->time_stamp);
         continue;
       }
-      std::string fname;
       std::string target_topic_name = bag_message->topic_name;
       if (target_topic_name.substr(0, 1) == "/") {
         target_topic_name = target_topic_name.substr(1);
       }
       target_topic_name = std::regex_replace(target_topic_name, std::regex("/"), "_");
-      fname = output_path_ + "/" + target_topic_name + "_" +
-              boost::lexical_cast<std::string>(image_msg->header.stamp.sec) + "." +
-              boost::lexical_cast<std::string>(image_msg->header.stamp.nanosec) + ".png";
+      const std::string fname = (boost::format("%s/%s/%09d.%09d.png") %
+              output_path_ %
+              target_topic_name %
+              image_msg->header.stamp.sec %
+              image_msg->header.stamp.nanosec).str();
 
       cv::imwrite(fname, image_msg->image);
       RCLCPP_INFO_STREAM(get_logger(), "Image saved to: " << fname);


### PR DESCRIPTION
## Issues in the Current Implementation

In the current implementation, there are two issues with the output file names:

### 1. Inconsistent Number of Digits

The number of digits in the timestamp is inconsistent, as shown below:

```
output/image_raw_1738133056.9658000.png
output/image_raw_1738133056.45788000.png
output/image_raw_1738133056.77710000.png
output/image_raw_1738133056.145716000.png
```

### 2. Files Are Saved Directly Under the `output` Directory

If the input ROS bag contains multiple topics (e.g., `image_raw` and `image_compressed`), all output files are stored in the same `output` directory without being organized by topic.

```
output/image_raw_1738133056.9658000.png  
output/image_compressed_1738133056.45788000.png  
```

## Updates in This PR

- The number of digits in the timestamp is now fixed for consistency.  
- Output files are now stored in separate directories based on the topic.  

As a result, the output file names are now more structured and easier to manage:

```
output/image_raw/1738133056.009658000.png  
output/image_raw/1738133056.045788000.png  
output/image_compressed/1738133056.077710000.png  
output/image_compressed/1738133056.145716000.png  
```