### PR TITLE
time_stamp typo for Humble

### DIFF
--- a/src/bag_to_image.cpp
+++ b/src/bag_to_image.cpp
@@ -95,7 +95,7 @@ void BagToImage::ReadBag() {
 #if __has_include("cv_bridge/cv_bridge.hpp") // ROS 2 jazzy and newer
           << " at " << bag_message->send_timestamp);
 #else // ROS 2 humble
-          << " at " << bag_message->timestamp);
+          << " at " << bag_message->time_stamp);
 #endif
         continue;
       }


### PR DESCRIPTION
In Humble, this should be time_stamp instead of timestamp, or it will not compile.